### PR TITLE
[v2.0.0-ea] Changelog date update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 
 ## RELEASE NOTES
 
-## [2.0.0-ea] (TBD)
+## [2.0.0-ea] June 09, 2021
 [2.0.0-ea]: https://github.com/emissary-ingress/emissary/compare/v2.0.0...v2.0.0-ea
 
 ### Emissary Ingress and Ambassador Edge Stack


### PR DESCRIPTION
Changelog date updates for 2.0.0-ea

Reviewers: The only changes in this PR should be updating the changelog entry for 2.0.0-ea to the date it was released.

If there are any other changes, the PR creator should note the reason.