### PR TITLE
[v2.0.1-ea] Release Branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,13 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 
 ## RELEASE NOTES
 
+## [2.0.1-ea] (TBD)
+[2.0.1-ea]: https://github.com/emissary-ingress/emissary/compare/v2.0.0-ea...v2.0.1-ea
+
+### Emissary Ingress and Ambassador Edge Stack
+
+(no changes yet)
+
 ## [2.0.0-ea] June 09, 2021
 [2.0.0-ea]: https://github.com/emissary-ingress/emissary/compare/v2.0.0...v2.0.0-ea
 

--- a/docs/yaml/versions.yml
+++ b/docs/yaml/versions.yml
@@ -1,2 +1,2 @@
-version: 2.0.0-ea
+version: 2.0.1-ea
 quoteVersion: 0.4.1


### PR DESCRIPTION

All commits that are going out in 2.0.1-ea release **must** be on rel/v2.0.1-ea.
This will allow the appropriate CI to run.

To get the hotfix changes onto this branch you can do one of the following:
    * use rel/v2.0.1-ea as the development branch for the fix
    * land (or have already landed) hotfix changes on release/v2.0 branch, and merge release/v2.0 into rel/v2.0.1-ea
    * cherry-pick hotfix commits from ambassador.git to rel/v2.0.1-ea

It is okay if you've already landed the hotfix changes on release/v2.0 branch,
reviewers just need to validate that the hotfix commits are in the tree for rel/v2.0.1-ea,
and all the appropriate changelog updates exist.

## REVIEWERS MUST CHECK THAT:
* hotfix commits are on rel/v2.0.1-ea
* CHANGELOG updates are on rel/v2.0.1-ea
