### PR TITLE
[v2.0.11-ea] Release Branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,13 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 
 (no changes yet)
 
+## [2.0.11-ea] (TBD)
+[2.0.11-ea]: https://github.com/emissary-ingress/emissary/compare/v2.0.10-ea...v2.0.11-ea
+
+### Emissary Ingress
+
+(no changes yet)
+
 ## [2.0.10-ea] (TBD)
 [2.0.10-ea]: https://github.com/emissary-ingress/emissary/compare/v2.0.2-ea...v2.0.10-ea
 

--- a/docs/yaml/versions.yml
+++ b/docs/yaml/versions.yml
@@ -1,2 +1,2 @@
-version: 2.0.10-ea
+version: 2.0.11-ea
 quoteVersion: 0.4.1

--- a/releng/release-go-changelog-update
+++ b/releng/release-go-changelog-update
@@ -94,7 +94,8 @@ def main(next_ver: str, today: datetime.date, quiet: bool=False, commit: bool = 
         user = 'unknownuser'
     workbranch = f"{user}/v{next_ver}/changelog-updates"
     with check(f"Creating new branch {workbranch}"):
-        run(["git", "fetch", "--tags"])
+        if getenv('CI') == '':
+            run(["git", "fetch", "--tags"])
         run(["git", "checkout", f"v{next_ver}", "-b", workbranch])
     if not checker.ok:
         return 1

--- a/releng/release-manifest-image-update
+++ b/releng/release-manifest-image-update
@@ -63,7 +63,8 @@ def main(next_ver: str, today: datetime.date, quiet: bool=False, commit: bool = 
         cur_branch = run_capture(['git', 'rev-parse', '--abbrev-ref', 'HEAD'])
 
         if cur_branch != workbranch:
-            run(["git", "fetch", "--tags"])
+            if getenv('CI') == '':
+                run(["git", "fetch", "--tags"])
             run(["git", "checkout", f"v{next_ver}", "-b", workbranch])
 
     if not checker.ok:


### PR DESCRIPTION

All commits that are going out in 2.0.11-ea release **must** be on rel/v2.0.11-ea.
This will allow the appropriate CI to run.

Reviewers, please review the changelog and commits in this branch to make sure everything that needs to go out in the release is on this branch.
