### PR TITLE
[v2.0.12-ea] Release Branch

### DIFF
--- a/.github/workflows/promote-ga.yml
+++ b/.github/workflows/promote-ga.yml
@@ -76,7 +76,7 @@ jobs:
           make release/ga/changelog-update
       - name: Extract branch name
         shell: bash
-        run: echo "::set-env name=PR_URL::$(gh pr view --json url --jq .url)"
+        run: echo "PR_URL=$(gh pr view --json url --jq .url)" >> $GITHUB_ENV
       #- name: Create github release
         #run: |
           #make release/ga/create-gh-release
@@ -119,7 +119,7 @@ jobs:
           make release/ga/manifest-update
       - name: Extract PR URL
         shell: bash
-        run: echo "::set-env name=PR_URL::$(gh pr view --json url --jq .url)"
+        run: echo "PR_URL=$(gh pr view --json url --jq .url)" >> $GITHUB_ENV
       - name: Slack notification
         if: always()
         uses: edge/simple-slack-notify@master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,13 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 
 (no changes yet)
 
+## [2.0.12-ea] (TBD)
+[2.0.12-ea]: https://github.com/emissary-ingress/emissary/compare/v2.0.11-ea...v2.0.12-ea
+
+### Emissary Ingress
+
+(no changes yet)
+
 ## [2.0.11-ea] (TBD)
 [2.0.11-ea]: https://github.com/emissary-ingress/emissary/compare/v2.0.10-ea...v2.0.11-ea
 

--- a/README.md
+++ b/README.md
@@ -63,3 +63,4 @@ If you're interested in contributing, here are some ways:
 * Add [more tests](https://github.com/datawire/ambassador/tree/master/ambassador/tests)
 
 The Ambassador Edge Stack is a superset of the Ambassador API Gateway that provides additional functionality including OAuth/OpenID Connect, advanced rate limiting, Swagger/OpenAPI support, integrated ACME support for automatic TLS certificate management, and a UI. For more information, visit https://www.getambassador.io/editions/.
+

--- a/docs/yaml/versions.yml
+++ b/docs/yaml/versions.yml
@@ -1,2 +1,2 @@
-version: 2.0.11-ea
+version: 2.0.12-ea
 quoteVersion: 0.4.1

--- a/releng/release.mk
+++ b/releng/release.mk
@@ -52,6 +52,6 @@ release/ga/create-gh-release:
 .PHONY: release/ga/create-gh-release
 
 release/ga/manifest-update:
-	$(OSS_HOME)/release-manifest-image-update --oss-version $(VERSIONS_YAML_VER)
+	$(OSS_HOME)/releng/release-manifest-image-update --oss-version $(VERSIONS_YAML_VER)
 .PHONY: release/ga/manifest-update
 


### PR DESCRIPTION

All commits that are going out in 2.0.12-ea release **must** be on rel/v2.0.12-ea.
This will allow the appropriate CI to run.

Reviewers, please review the changelog and commits in this branch to make sure everything that needs to go out in the release is on this branch.
