### PR TITLE
[v2.0.14-ea] Release Branch

### DIFF
--- a/.github/workflows/publish-chart.yml
+++ b/.github/workflows/publish-chart.yml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     name: chart-publish
     env:
+      AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
       AWS_ACCESS_KEY_ID: ${{ secrets.GH_AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.GH_AWS_SECRET_ACCESS_KEY }}
       AWS_EC2_METADATA_DISABLED: true

--- a/.github/workflows/publish-manifests.yml
+++ b/.github/workflows/publish-manifests.yml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     name: manifest-publish
     env:
+      AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
       AWS_ACCESS_KEY_ID: ${{ secrets.GH_AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.GH_AWS_SECRET_ACCESS_KEY }}
       AWS_EC2_METADATA_DISABLED: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,13 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 
 (no changes yet)
 
+## [2.0.14-ea] (TBD)
+[2.0.14-ea]: https://github.com/emissary-ingress/emissary/compare/v2.0.13-ea...v2.0.14-ea
+
+### Emissary Ingress
+
+(no changes yet)
+
 ## [2.0.13-ea] (TBD)
 [2.0.13-ea]: https://github.com/emissary-ingress/emissary/compare/v2.0.2-ea...v2.0.13-ea
 

--- a/docs/yaml/versions.yml
+++ b/docs/yaml/versions.yml
@@ -1,2 +1,2 @@
-version: 2.0.13-ea
+version: 2.0.14-ea
 quoteVersion: 0.4.1

--- a/releng/release-create-github
+++ b/releng/release-create-github
@@ -81,7 +81,7 @@ def main(release_version: str) -> int:
             "--notes", RELEASE_BODY_FORMAT.format(release_version=release_version, release_notes=buf)])
     if not checker.ok:
         return 1
-    if getenv("AMBASSADOR_RELENG_NO_GUI") == '':
+    if os.getenv("AMBASSADOR_RELENG_NO_GUI") == '':
         print('Release info from github:')
         run(["gh", "release", "view", "--repo", get_gh_repo(), f"v{release_version}"])
     if checker.ok:


### PR DESCRIPTION

All commits that are going out in 2.0.14-ea release **must** be on rel/v2.0.14-ea.
This will allow the appropriate CI to run.

Reviewers, please review the changelog and commits in this branch to make sure everything that needs to go out in the release is on this branch.
