### PR TITLE
[v2.0.15-ea] Release Branch

### DIFF
--- a/.github/workflows/execute-chart-test.yml
+++ b/.github/workflows/execute-chart-test.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     name: chart-test
     env:
+      AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
       AWS_ACCESS_KEY_ID: ${{ secrets.GH_AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.GH_AWS_SECRET_ACCESS_KEY }}
       AWS_EC2_METADATA_DISABLED: true

--- a/.github/workflows/publish-manifests.yml
+++ b/.github/workflows/publish-manifests.yml
@@ -12,6 +12,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.GH_AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.GH_AWS_SECRET_ACCESS_KEY }}
       AWS_EC2_METADATA_DISABLED: true
+      BUMP_STABLE: true
     steps:
       - uses: actions/checkout@v2
       - name: make push-manifests
@@ -20,6 +21,8 @@ jobs:
       - name: make publish-docs-yaml
         run: |
           make publish-docs-yaml
+          ver_yaml_version=`grep 'version:' docs/yaml/versions.yml | sed 's/version://g'`
+          echo "RELEASED_VERSION=${ver_yaml_version}" >> $GITHUB_ENV
       - name: Slack notification
         if: always()
         uses: edge/simple-slack-notify@master
@@ -27,7 +30,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:
           status: ${{ job.status }}
-          success_text: 'Manifests successfully published for ${env.GITHUB_REF}'
+          success_text: 'Manifests successfully published for ${env.RELEASED_VERSION}'
           failure_text: '${env.GITHUB_WORKFLOW} (${env.GITHUB_RUN_NUMBER}) build failed'
           cancelled_text: '${env.GITHUB_WORKFLOW} (${env.GITHUB_RUN_NUMBER}) build was cancelled'
           fields: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,13 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 
 (no changes yet)
 
+## [2.0.15-ea] (TBD)
+[2.0.15-ea]: https://github.com/emissary-ingress/emissary/compare/v2.0.14-ea...v2.0.15-ea
+
+### Emissary Ingress
+
+(no changes yet)
+
 ## [2.0.14-ea] (TBD)
 [2.0.14-ea]: https://github.com/emissary-ingress/emissary/compare/v2.0.13-ea...v2.0.14-ea
 

--- a/charts/emissary-ingress/Chart.yaml
+++ b/charts/emissary-ingress/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 2.0.2-ea
 description: A Helm chart for Emissary Ingress
 name: emissary-ingress
-version: 7.1.2-ea
+version: 7.2.0-ea
 icon: https://www.getambassador.io/images/logo.png
 home: https://www.getambassador.io/
 sources:

--- a/docs/yaml/versions.yml
+++ b/docs/yaml/versions.yml
@@ -1,2 +1,2 @@
-version: 2.0.14-ea
+version: 2.0.15-ea
 quoteVersion: 0.4.1


### PR DESCRIPTION

All commits that are going out in 2.0.15-ea release **must** be on rel/v2.0.15-ea.
This will allow the appropriate CI to run.

Reviewers, please review the changelog and commits in this branch to make sure everything that needs to go out in the release is on this branch.
