### PR TITLE
[v2.0.17-ea] Release Branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,13 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 
 (no changes yet)
 
+## [2.0.17-ea] (TBD)
+[2.0.17-ea]: https://github.com/emissary-ingress/emissary/compare/v2.0.16-ea...v2.0.17-ea
+
+### Emissary Ingress
+
+(no changes yet)
+
 ## [2.0.16-ea] (TBD)
 [2.0.16-ea]: https://github.com/emissary-ingress/emissary/compare/v2.0.15-ea...v2.0.16-ea
 

--- a/docs/yaml/versions.yml
+++ b/docs/yaml/versions.yml
@@ -1,2 +1,2 @@
-version: 2.0.16-ea
+version: 2.0.17-ea
 quoteVersion: 0.4.1


### PR DESCRIPTION

All commits that are going out in 2.0.17-ea release **must** be on rel/v2.0.17-ea.
This will allow the appropriate CI to run.

Reviewers, please review the changelog and commits in this branch to make sure everything that needs to go out in the release is on this branch.
